### PR TITLE
fix: add script for installing hyperd on nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,3 +53,12 @@ $ ./git-latest.sh
 $ cat VERSION
 v1.2.3
 ```
+
+## Install hyperd and its dependencies on nodes
+You need to ssh to the K8S nodes first and then run the script. The script will install hyperd and its dependencies and start the hyperd service. Hyperd is needed to start a vm with `executor-k8s-vm`.
+
+```bash
+$ sudo bash ./hyper_install.sh
+$ sudo hyperctl list # To ensure the script installed correctly
+POD ID              POD Name            VM name             Status
+```

--- a/hyper_install.sh
+++ b/hyper_install.sh
@@ -1,0 +1,27 @@
+#!/bin/bash -e
+
+echo Downloading dependencies, qemu-hyper, hyper-container and hyperstart
+cd /tmp
+sudo DEBIAN_FRONTEND=noninteractive apt-get -f install -y
+sudo DEBIAN_FRONTEND=noninteractive apt-get update -qq
+sudo DEBIAN_FRONTEND=noninteractive apt-get install -y autoconf automake pkg-config libdevmapper-dev libsqlite3-dev libvirt-dev libvirt-bin -qq
+wget https://hypercontainer-download.s3-us-west-1.amazonaws.com/qemu-hyper/qemu-hyper_2.4.1-1_amd64.deb && sudo dpkg -i --force-all qemu-hyper_2.4.1-1_amd64.deb
+wget https://hypercontainer-download.s3-us-west-1.amazonaws.com/0.8/debian/hypercontainer_0.8.1-1_amd64.deb && sudo dpkg -i --force-all hypercontainer_0.8.1-1_amd64.deb
+wget https://hypercontainer-download.s3-us-west-1.amazonaws.com/0.8/debian/hyperstart_0.8.1-1_amd64.deb && sudo dpkg -i --force-all hyperstart_0.8.1-1_amd64.deb
+
+echo Overriding the hyper config file
+cat > /etc/hyper/config << 'EOF'
+# Boot kernel
+Kernel=/var/lib/hyper/kernel
+# Boot initrd
+Initrd=/var/lib/hyper/hyper-initrd.img
+# Storage driver for hyperd, valid value includes devicemapper, overlay, and aufs
+StorageDriver=devicemapper
+# Hypervisor to run containers and pods, valid values are: libvirt, qemu, kvm, xen
+Hypervisor=qemu
+EOF
+
+echo Start the hyperd service
+systemctl daemon-reload; systemctl enable hyperd; systemctl start hyperd
+
+


### PR DESCRIPTION
- add script for installing hyperd on nodes 

`hyperd` is needed to support `executor-k8s-vm`

Related to https://github.com/screwdriver-cd/screwdriver/issues/595
