### PR TITLE
fix: Update token extraction line for docker-wait

### DIFF
--- a/docker-wait.sh
+++ b/docker-wait.sh
@@ -7,7 +7,7 @@ if [ -z "$DOCKER_TAG" ] || [ -z "$DOCKER_REPO" ]; then
 fi
 
 function check_status {
-  TOKEN=`wget -q -O - "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$DOCKER_REPO:pull" | sed -e 's/{"token":"//g' -e 's/"}//g'`
+  TOKEN=`wget -q -O - "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$DOCKER_REPO:pull" | python -c "import sys, json; print(json.load(sys.stdin))['token']"`
   wget -S --spider -q --header="Authorization: Bearer $TOKEN" https://index.docker.io/v2/$DOCKER_REPO/manifests/$DOCKER_TAG > /dev/null 2>&1
 }
 


### PR DESCRIPTION
A change was made to St. John's scripts and was never updated in the toolbox scripts. Now that we're pulling in toolbox scripts in more places, we need to update this line to match.

https://gist.github.com/stjohnjohnson/3d2388b2a7ba658cdcdaffa8cd874e50#gistcomment-1934894