### PR TITLE
fix: Add old ssh fingerprint

### DIFF
--- a/git-ssh.sh
+++ b/git-ssh.sh
@@ -5,7 +5,11 @@ if [ -z "$GIT_KEY" ]; then
   exit 2
 fi
 
-GITHUB_FINGERPRINT=SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+// https://github.com/screwdriver-cd/screwdriver/issues/729
+// For openssh < 7.4
+OLD_GITHUB_FINGERPRINT=16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48
+// For openssh >= 7.4
+NEW_GITHUB_FINGERPRINT=SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 
 echo Addding github.com to known_hosts
 mkdir -p /root/.ssh
@@ -14,7 +18,7 @@ ssh-keyscan -H github.com >> /root/.ssh/known_hosts
 chmod 600 /root/.ssh/known_hosts
 
 echo Validating good known_hosts
-ssh-keygen -l -f ~/.ssh/known_hosts | grep $GITHUB_FINGERPRINT
+ssh-keygen -l -f ~/.ssh/known_hosts | grep -e "$NEW_GITHUB_FINGERPRINT" -e "$OLD_GITHUB_FINGERPRINT"
 
 echo Starting ssh-agent
 eval "$(ssh-agent -s)"


### PR DESCRIPTION
Sometimes the openssh version is < 7.4 and you still need to the old ssh fingerprint (ie: for node:6 vs. golang)