### PR TITLE
fix: should use proper comment syntax

### DIFF
--- a/git-ssh.sh
+++ b/git-ssh.sh
@@ -5,10 +5,10 @@ if [ -z "$GIT_KEY" ]; then
   exit 2
 fi
 
-// https://github.com/screwdriver-cd/screwdriver/issues/729
-// For openssh < 7.4
+# https://github.com/screwdriver-cd/screwdriver/issues/729
+# For openssh < 7.4
 OLD_GITHUB_FINGERPRINT=16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48
-// For openssh >= 7.4
+# For openssh >= 7.4
 NEW_GITHUB_FINGERPRINT=SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
 
 echo Addding github.com to known_hosts


### PR DESCRIPTION
Switching from `//` to `#` for bash comments