### PR TITLE
fix: update npm-dups.sh to work with node8

### DIFF
--- a/npm-dups.sh
+++ b/npm-dups.sh
@@ -9,9 +9,10 @@ echo Searching for filtered packages
 npm ls | grep $NPM_FILTER | tee /tmp/npm.filter
 
 echo Reducing to duplicate packages
-cat /tmp/npm.filter | sed -E -e 's/[^a-zA-Z_-]//g' | sort | uniq -iD > /tmp/npm.dups
+cat /tmp/npm.filter | sed -E -e 's/[^0-9a-zA-Z_-]//g' | sed -E -e 's/deduped//g' | sort | uniq | sed -E -e 's/[0-9]//g' | uniq -c | grep -v "^ *1 " > /tmp/npm.dups
 if [ -s /tmp/npm.dups ] ; then
   echo Duplicate packages found, failing build
+  cat /tmp/npm.dups
   exit 1
 else
   echo No duplicate packages found


### PR DESCRIPTION
update npm-dups.sh to make it work with `node8`.

with `node:8`, when you do `npm ls`, it will list duplicate pkgs with keyword `deduped` when they share the same version but in `node:6` it won't print out the dup pkg with same version. So when we user `image: node:8` for screwdriver, it failed at this step even though there is no duplicate pkg with different version.

node8: https://cd.screwdriver.cd/pipelines/1/builds/16958
node6: https://cd.screwdriver.cd/pipelines/1/builds/16960



