### PR TITLE
fix: switch back to uniq -iD

### DIFF
--- a/npm-dups.sh
+++ b/npm-dups.sh
@@ -9,7 +9,7 @@ echo Searching for filtered packages
 npm ls | grep $NPM_FILTER | tee /tmp/npm.filter
 
 echo Reducing to duplicate packages
-cat /tmp/npm.filter | sed -E -e 's/[^0-9a-zA-Z_-]//g' | sed -E -e 's/deduped//g' | sort | uniq | sed -E -e 's/[0-9]//g' | uniq -c | grep -v "^ *1 " > /tmp/npm.dups
+cat /tmp/npm.filter | sed -E -e 's/[^0-9a-zA-Z_-]//g' | sed -E -e 's/deduped//g' | sort | uniq | sed -E -e 's/[0-9]//g' | uniq -iD > /tmp/npm.dups
 if [ -s /tmp/npm.dups ] ; then
   echo Duplicate packages found, failing build
   cat /tmp/npm.dups


### PR DESCRIPTION
somehow 'uniq -c | grep -E xxx'  doesn't work with `./npm-dups.sh`. Switched back to`uniq -iD`.