### PR TITLE
fix: Only check first line for 200

### DIFF
--- a/k8s-deploy.sh
+++ b/k8s-deploy.sh
@@ -27,4 +27,4 @@ curl -k -i \
   -H "Content-Type: application/strategic-merge-patch+json" \
   -d $BODY \
   $URL > /tmp/k8s_out
-grep "200 OK" /tmp/k8s_out || (echo "Failed deployment" && cat /tmp/k8s_out && exit 1)
+head -1 /tmp/k8s_out | grep "200" || (echo "Failed deployment" && cat /tmp/k8s_out && exit 1)


### PR DESCRIPTION
## Context
Guide builds are marked as failed because we're grepping for "200 OK" which was the response for HTTP/1.1 but HTTP/2 only returns "200".

https://cd.screwdriver.cd/pipelines/27/builds/15760

## Objective
This PR onlys greps the first line of the file for 200. Should resolve false failures issue.

## Related links
HTTP versions: https://en.wikipedia.org/wiki/HTTP/2