### PR TITLE
fix: Update git-release.sh

### DIFF
--- a/git-release.sh
+++ b/git-release.sh
@@ -9,8 +9,8 @@ fi
 GITHUB_RELEASE=/tmp/bin/linux/amd64/github-release
 if [ ! -f "$GITHUB_RELEASE" ] ; then
   echo Downloading github-release
-  wget -q -O - https://github.com/aktau/github-release/releases/latest \
-     | egrep -o '/aktau/github-release/releases/download/v[0-9.]*/linux-amd64-github-release.tar.bz2' \
+  wget -q -O - https://github.com/github-release/github-release/releases/latest \
+     | egrep -o '/github-release/github-release/releases/download/v[0-9.]*/linux-amd64-github-release.tar.bz2' \
      | wget --base=http://github.com/ -i - -O /tmp/linux-amd64-github-release.tar.bz2
   tar -xvf /tmp/linux-amd64-github-release.tar.bz2 -C /tmp
   chmod +x $GITHUB_RELEASE


### PR DESCRIPTION
## Context

The git-release repo moved orgs, causing errors when trying to publish: https://cd.screwdriver.cd/pipelines/27/builds/228453/steps/publish.

## Objective

This PR updates the org to match.

## References

https://github.com/aktau/github-release/releases/tag/v0.7.2

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
