### PR TITLE
fix: github-release no longer tars the file

### DIFF
--- a/git-release.sh
+++ b/git-release.sh
@@ -6,13 +6,13 @@ if [ -z "$GITHUB_TOKEN" ] || [ -z "$RELEASE_FILE" ]; then
   exit 2
 fi
 
-GITHUB_RELEASE=/tmp/bin/linux/amd64/github-release
+GITHUB_RELEASE=/tmp/linux-amd64-github-release
 if [ ! -f "$GITHUB_RELEASE" ] ; then
   echo Downloading github-release
   wget -q -O - https://github.com/github-release/github-release/releases/latest \
      | egrep -o '/github-release/github-release/releases/download/v[0-9.]*/linux-amd64-github-release.tar.bz2' \
      | wget --base=http://github.com/ -i - -O /tmp/linux-amd64-github-release.tar.bz2
-  tar -xvf /tmp/linux-amd64-github-release.tar.bz2 -C /tmp
+  bzip2 -dv /tmp/linux-amd64-github-release.bz2
   chmod +x $GITHUB_RELEASE
 fi
 

--- a/git-release.sh
+++ b/git-release.sh
@@ -10,8 +10,8 @@ GITHUB_RELEASE=/tmp/linux-amd64-github-release
 if [ ! -f "$GITHUB_RELEASE" ] ; then
   echo Downloading github-release
   wget -q -O - https://github.com/github-release/github-release/releases/latest \
-     | egrep -o '/github-release/github-release/releases/download/v[0-9.]*/linux-amd64-github-release.tar.bz2' \
-     | wget --base=http://github.com/ -i - -O /tmp/linux-amd64-github-release.tar.bz2
+     | egrep -o '/github-release/github-release/releases/download/v[0-9.]*/linux-amd64-github-release.bz2' \
+     | wget --base=http://github.com/ -i - -O /tmp/linux-amd64-github-release.bz2
   bzip2 -dv /tmp/linux-amd64-github-release.bz2
   chmod +x $GITHUB_RELEASE
 fi


### PR DESCRIPTION
## Context

A new release yesterday removed the tar: https://github.com/github-release/github-release/commit/b61ce1a1426379d208f188311954fde680ac99f0

## Objective

This PR handles the new file type.

## References

Related to https://github.com/github-release/github-release/releases

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
