### PR TITLE
fix: Check github-release version

### DIFF
--- a/git-release.sh
+++ b/git-release.sh
@@ -35,5 +35,6 @@ fi
 
 echo "Creating release $GIT_TAG for $GIT_ORG / $GIT_REPO"
 
+$GITHUB_RELEASE --version
 $GITHUB_RELEASE release --user $GIT_ORG --repo $GIT_REPO --tag $GIT_TAG --name $GIT_TAG
 $GITHUB_RELEASE upload --user $GIT_ORG --repo $GIT_REPO --tag $GIT_TAG --name $RELEASE_FILE --file $RELEASE_FILE


### PR DESCRIPTION
## Context

Not sure which version of github-release is getting downloaded.

## Objective

This PR prints out the github-release version.

## References

Related to https://github.com/github-release/github-release/issues/102

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
