### PR TITLE
fix: use gitversion from launcher path in build

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ $ ./docker-wait.sh
 ## Get Latest Tag
 Checks the Git tags for the latest version and writes it to a file.
 
+*requires either Linux or Screwdriver build environment to run*
+
 ```bash
 $ ./git-latest.sh
 $ cat VERSION

--- a/git-latest.sh
+++ b/git-latest.sh
@@ -1,12 +1,6 @@
 #!/bin/bash -e
 
-GIT_VERSION=/tmp/gitversion
-if [ ! -f "$GIT_VERSION" ] ; then
-    echo Downloading gitversion
-    GIT_URI_PATH=$(wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64')
-    wget -O $GIT_VERSION http://github.com/$GIT_URI_PATH
-    chmod +x $GIT_VERSION
-fi
-
+# https://github.com/screwdriver-cd/gitversion/releases
+GIT_VERSION=/opt/sd/gitversion
 echo Finding version
 $GIT_VERSION --prefix v show | tee VERSION

--- a/git-latest.sh
+++ b/git-latest.sh
@@ -1,6 +1,17 @@
 #!/bin/bash -e
 
 # https://github.com/screwdriver-cd/gitversion/releases
-GIT_VERSION=/opt/sd/gitversion
+if [ "$SCREWDRIVER" == true ]; then
+  GIT_VERSION=/opt/sd/gitversion
+else
+  GIT_VERSION=/tmp/gitversion
+  if [ ! -f "$GIT_VERSION" ] ; then
+    echo Downloading gitversion
+    wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest \
+      | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64' \
+      | wget --base=http://github.com/ -i - -O /tmp/gitversion
+    chmod +x $GIT_VERSION
+  fi
+fi
 echo Finding version
 $GIT_VERSION --prefix v show | tee VERSION

--- a/git-release.sh
+++ b/git-release.sh
@@ -17,14 +17,8 @@ if [ ! -f "$GITHUB_RELEASE" ] ; then
   chmod +x $GITHUB_RELEASE
 fi
 
-GIT_VERSION=/tmp/gitversion
-if [ ! -f "$GIT_VERSION" ] ; then
-    echo Downloading gitversion
-    wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest \
-       | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64' \
-       | wget --base=http://github.com/ -i - -O /tmp/gitversion
-    chmod +x $GIT_VERSION
-fi
+# https://github.com/screwdriver-cd/gitversion/releases
+GIT_VERSION=/opt/sd/gitversion
 
 GIT_ORG=`git remote -v | grep fetch | sed 's/ (fetch)//' | cut -d'/' -f4`
 GIT_REPO=`git remote -v | grep fetch | sed 's/ (fetch)//' | cut -d'/' -f5`

--- a/git-release.sh
+++ b/git-release.sh
@@ -18,7 +18,18 @@ if [ ! -f "$GITHUB_RELEASE" ] ; then
 fi
 
 # https://github.com/screwdriver-cd/gitversion/releases
-GIT_VERSION=/opt/sd/gitversion
+if [ "$SCREWDRIVER" == true ]; then
+  GIT_VERSION=/opt/sd/gitversion
+else
+  GIT_VERSION=/tmp/gitversion
+  if [ ! -f "$GIT_VERSION" ] ; then
+    echo Downloading gitversion
+    wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest \
+      | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64' \
+      | wget --base=http://github.com/ -i - -O /tmp/gitversion
+    chmod +x $GIT_VERSION
+  fi
+fi
 
 GIT_ORG=`git remote -v | grep fetch | sed 's/ (fetch)//' | cut -d'/' -f4`
 GIT_REPO=`git remote -v | grep fetch | sed 's/ (fetch)//' | cut -d'/' -f5`

--- a/git-tag.sh
+++ b/git-tag.sh
@@ -5,7 +5,18 @@ echo Setting up git SSH
 source $DIR/git-ssh.sh
 
 # https://github.com/screwdriver-cd/gitversion/releases
-GIT_VERSION=/opt/sd/gitversion
+if [ "$SCREWDRIVER" == true ]; then
+  GIT_VERSION=/opt/sd/gitversion
+else
+  GIT_VERSION=/tmp/gitversion
+  if [ ! -f "$GIT_VERSION" ] ; then
+    echo Downloading gitversion
+    wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest \
+      | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64' \
+      | wget --base=http://github.com/ -i - -O /tmp/gitversion
+    chmod +x $GIT_VERSION
+  fi
+fi
 echo Bumping version
 $GIT_VERSION --prefix v bump auto | tee VERSION
 

--- a/git-tag.sh
+++ b/git-tag.sh
@@ -4,15 +4,8 @@ DIR="$(cd "$(dirname "$0")" && pwd)"
 echo Setting up git SSH
 source $DIR/git-ssh.sh
 
-GIT_VERSION=/tmp/gitversion
-if [ ! -f "$GIT_VERSION" ] ; then
-    echo Downloading gitversion
-    wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest \
-       | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64' \
-       | wget --base=http://github.com/ -i - -O /tmp/gitversion
-    chmod +x $GIT_VERSION
-fi
-
+# https://github.com/screwdriver-cd/gitversion/releases
+GIT_VERSION=/opt/sd/gitversion
 echo Bumping version
 $GIT_VERSION --prefix v bump auto | tee VERSION
 

--- a/publish.sh
+++ b/publish.sh
@@ -24,14 +24,8 @@ echo Push the new tag to GitHub
 git push origin --tags -q
 
 echo Tee latest tag to VERSION
-GIT_VERSION=/tmp/gitversion
-if [ ! -f "$GIT_VERSION" ] ; then
-    echo Downloading gitversion
-    wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest \
-       | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64' \
-       | wget --base=http://github.com/ -i - -O /tmp/gitversion
-    chmod +x $GIT_VERSION
-fi
+# https://github.com/screwdriver-cd/gitversion/releases
+GIT_VERSION=/opt/sd/gitversion
 
 echo Getting latest version
 $GIT_VERSION --prefix v show | tee VERSION

--- a/publish.sh
+++ b/publish.sh
@@ -25,7 +25,18 @@ git push origin --tags -q
 
 echo Tee latest tag to VERSION
 # https://github.com/screwdriver-cd/gitversion/releases
-GIT_VERSION=/opt/sd/gitversion
+if [ "$SCREWDRIVER" == true ]; then
+  GIT_VERSION=/opt/sd/gitversion
+else
+  GIT_VERSION=/tmp/gitversion
+  if [ ! -f "$GIT_VERSION" ] ; then
+    echo Downloading gitversion
+    wget -q -O - https://github.com/screwdriver-cd/gitversion/releases/latest \
+      | egrep -o '/screwdriver-cd/gitversion/releases/download/v[0-9.]*/gitversion_linux_amd64' \
+      | wget --base=http://github.com/ -i - -O /tmp/gitversion
+    chmod +x $GIT_VERSION
+  fi
+fi
 
 echo Getting latest version
 $GIT_VERSION --prefix v show | tee VERSION


### PR DESCRIPTION
## Context

gitversion is now available in launcher, no need to download it each time when used.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
