### PR TITLE
fix: use jq instead of python

### DIFF
--- a/docker-wait.sh
+++ b/docker-wait.sh
@@ -7,7 +7,7 @@ if [ -z "$DOCKER_TAG" ] || [ -z "$DOCKER_REPO" ]; then
 fi
 
 function check_status {
-  TOKEN=`wget -q -O - "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$DOCKER_REPO:pull" | python -c "import sys, json; print(json.load(sys.stdin))['token']"`
+  TOKEN=`wget -q -O - "https://auth.docker.io/token?service=registry.docker.io&scope=repository:$DOCKER_REPO:pull" | jq -r '.token'`
   wget -S --spider -q --header="Authorization: Bearer $TOKEN" https://index.docker.io/v2/$DOCKER_REPO/manifests/$DOCKER_TAG > /dev/null 2>&1
 }
 


### PR DESCRIPTION
## Context

Python v3 binary name is`python3` while v2 has `python` it's better to use `jq` since SD launcher bundles it.

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

https://cd.screwdriver.cd/pipelines/27/builds/738427/steps/wait-docker

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
