### PR TITLE
fix: add logs for troubleshooting released files

### DIFF
--- a/git-release.sh
+++ b/git-release.sh
@@ -42,19 +42,27 @@ fi
 echo "Creating release $GIT_TAG for $GIT_ORG / $GIT_REPO"
 
 $GITHUB_RELEASE --version
+
+echo "Creating tag $GIT_TAG for $GIT_ORG / $GIT_REPO"
+
 $GITHUB_RELEASE release --user $GIT_ORG --repo $GIT_REPO --tag $GIT_TAG --name $GIT_TAG
 
 if [ ! -z "$RELEASE_FILES" ];then
-  files=($RELEASE_FILES) 
+  files=($RELEASE_FILES)
+
+  echo "Uploading files..."
+
   for i in "${files[@]}"
   do
     if [ -f $i ];then
+      echo "Uploading file: $i"
       $GITHUB_RELEASE upload --user $GIT_ORG --repo $GIT_REPO --tag $GIT_TAG --name $i --file $i
     else
       echo "Unable to release, file does not exist"
     fi
   done
 else
+  echo "Uploading file: $RELEASE_FILE"
   $GITHUB_RELEASE upload --user $GIT_ORG --repo $GIT_REPO --tag $GIT_TAG --name $RELEASE_FILE --file $RELEASE_FILE
 fi
 


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
UI pipeline, i.e. https://cd.screwdriver.cd/pipelines/7/builds/779600/steps/publish is blocked due to 
```
error: could not find the release corresponding to tag v1.0.672
```
Add logs to troubleshoot

## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
```
/tmp/darwin-amd64-github-release --help  

Usage: darwin-amd64-github-release [global options] <verb> [verb options]

Global options:
        -h, --help           Show this help
        -v, --verbose        Be verbose
        -q, --quiet          Do not print anything, even errors (except if --verbose is specified)
            --version        Print version

Verbs:
    delete:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -a, --auth-user      Username for authenticating to the API (falls back to $GITHUB_AUTH_USER or $GITHUB_USER)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag of release to delete (*)
    download:
        -s, --security-token Github token ($GITHUB_TOKEN if set). required if repo is private.
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -a, --auth-user      Username for authenticating to the API (falls back to $GITHUB_AUTH_USER or $GITHUB_USER)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -l, --latest         Download latest release (required if tag is not specified)
        -t, --tag            Git tag to download from (required if latest is not specified) (*)
        -n, --name           Name of the file (*)
    edit:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -a, --auth-user      Username for authenticating to the API (falls back to $GITHUB_AUTH_USER or $GITHUB_USER)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to edit the release of (*)
        -n, --name           New name of the release (defaults to tag)
        -d, --description    New release description, use - for reading a description from stdin (defaults to tag)
            --draft          The release is a draft
        -p, --pre-release    The release is a pre-release
    info:
        -s, --security-token Github token ($GITHUB_TOKEN if set). required if repo is private.
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -a, --auth-user      Username for authenticating to the API (falls back to $GITHUB_AUTH_USER or $GITHUB_USER)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to query (optional)
        -j, --json           Emit info as JSON instead of text
    release:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to create a release from (*)
        -n, --name           Name of the release (defaults to tag)
        -d, --description    Release description, use - for reading a description from stdin (defaults to tag)
        -c, --target         Commit SHA or branch to create release of (defaults to the repository default branch)
            --draft          The release is a draft
        -p, --pre-release    The release is a pre-release
    upload:
        -s, --security-token Github token (required if $GITHUB_TOKEN not set)
        -u, --user           Github repo user or organisation (required if $GITHUB_USER not set)
        -a, --auth-user      Username for authenticating to the API (falls back to $GITHUB_AUTH_USER or $GITHUB_USER)
        -r, --repo           Github repo (required if $GITHUB_REPO not set)
        -t, --tag            Git tag to upload to (*)
        -n, --name           Name of the file (*)
        -l, --label          Label (description) of the file
        -f, --file           File to upload (use - for stdin) (*)
        -R, --replace        Replace asset with same name if it already exists (WARNING: not atomic, failure to upload will remove the original asset too)
```
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
