### PR TITLE
fix: update GitHub's SSH key fingerprints

### DIFF
--- a/git-ssh.sh
+++ b/git-ssh.sh
@@ -16,7 +16,7 @@ fi
 # For openssh < 7.4
 OLD_GITHUB_FINGERPRINT=16:27:ac:a5:76:28:2d:36:63:1b:56:4d:eb:df:a6:48
 # For openssh >= 7.4
-NEW_GITHUB_FINGERPRINT=SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8
+NEW_GITHUB_FINGERPRINT=SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s
 
 echo Addding github.com to known_hosts
 mkdir -p /root/.ssh


### PR DESCRIPTION
## Context

<!-- Why do we need this PR? What was the reason that led you to make this change? -->
Build keeps failing on  `Validating good known_hosts`
![image](https://user-images.githubusercontent.com/15989893/228921155-e2f0bb00-a1a2-40cd-9e98-6f7f5d7ab252.png)

Sample PR: 
https://cd.screwdriver.cd/pipelines/27/builds/853977/steps/tag
https://cd.screwdriver.cd/pipelines/7/builds/854332/steps/tag

It _appears_ the fingerprints for Github's RSA Key is outdated.

https://github.com/screwdriver-cd/toolbox/blob/3af51dd86eb7c40c5ba3351cc6935cb326991179/git-ssh.sh#L27-L28
## Objective

<!-- What does this PR fix? What intentional changes will this PR make? -->
Updating GitHub's SSH key fingerprints for RSA 
from

`SHA256:nThbg6kXUpJWGl7E1IGOCspRomTxdCARLviKw6E5SY8`

to

`SHA256:uNiVztksCsDhcc0u9e8BujQXVUpKZIDTMczCvj3tD2s`

![image](https://user-images.githubusercontent.com/15989893/228921194-985d6e6f-1f84-47ac-ba40-c4c0592a4a92.png)


## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->
[Latest GitHub's SSH key fingerprints]
(https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/githubs-ssh-key-fingerprints)
Related PR: https://github.com/screwdriver-cd/screwdriver/issues/729
## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
