### PR TITLE
fix: proper tagging of multi-arch images

### DIFF
--- a/docker-tag.sh
+++ b/docker-tag.sh
@@ -8,6 +8,4 @@ if [ -z "$IMAGE" ] || [ -z "$VERSION" ] || [ -z "$TYPE" ]; then
   exit 2
 fi
 
-docker pull screwdrivercd/$IMAGE:$VERSION
-docker tag screwdrivercd/$IMAGE:$VERSION screwdrivercd/$IMAGE:$TYPE
-docker push screwdrivercd/$IMAGE:$TYPE
+docker buildx imagetools create -t screwdrivercd/$IMAGE:$TYPE screwdrivercd/$IMAGE:$VERSION


### PR DESCRIPTION
## Context

Current way of tagging doesn't work for multi-arch images

## Objective



## References

https://docs.docker.com/engine/reference/commandline/buildx_imagetools_create/

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
