### PR TITLE
feat: add retry logic while querying git tag

### DIFF
--- a/git-release.sh
+++ b/git-release.sh
@@ -46,7 +46,23 @@ echo "Creating tag $GIT_TAG for $GIT_ORG / $GIT_REPO"
 $GITHUB_RELEASE release --user $GIT_ORG --repo $GIT_REPO --tag $GIT_TAG --name $GIT_TAG
 
 echo "Querying tag $GIT_TAG for $GIT_ORG / $GIT_REPO"
-$GITHUB_RELEASE info --user $GIT_ORG --repo $GIT_REPO --tag $GIT_TAG
+max_attempts=5
+attempt=1
+while [ $attempt -le $max_attempts ]; do
+  if $GITHUB_RELEASE info --user "$GIT_ORG" --repo "$GIT_REPO" --tag "$GIT_TAG"; then
+    echo "Successfully retrieved release info on attempt $attempt"
+    break
+  else
+    echo "Attempt $attempt: Failed to query release info. Retrying in 5 seconds..."
+    sleep 5
+    attempt=$((attempt + 1))
+  fi
+done
+
+if [ $attempt -gt $max_attempts ]; then
+  echo "Failed to query release info after $max_attempts attempts. Exiting."
+  exit 1
+fi
 
 if [ ! -z "$RELEASE_FILES" ];then
   files=($RELEASE_FILES)


### PR DESCRIPTION
## Context

There is a race condition after creating tag and then querying it.

## Objective

Fir race condition on tag query
``` github-release v0.10.0
14:38:16 Creating tag v0.0.36 for screwdriver-cd / sd-packages
14:38:16 Querying tag v0.0.36 for screwdriver-cd / sd-packages
14:38:17 error: could not find the release corresponding to tag v0.0.36
```

## References

<!-- Links or resources that help clarify and support your intentions (e.g., Github issue) -->

## License

<!-- The following line must be included in your pull request -->

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
