### PR TITLE
feat: Add GIT_KEY_BASE64 in publish.sh as permitted env var

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # GIT_KEY = SSH Deployment key
 # NPM_TOKEN = NPM token for publishing the module
-if [ -z "$GIT_KEY" ] || [ -z "$NPM_TOKEN" ]; then
+if [ -z "$GIT_KEY" ] || [ -z "$GIT_KEY_BASE64" ] || [ -z "$NPM_TOKEN" ]; then
   echo Unable to publish, missing environment variables
   exit 2
 fi


### PR DESCRIPTION
## Context

The publish script currently verifies the presence of two environment variables before terminating the program if they are missing.

## Objective

Include $GIT_KEY_BASE64 as a valid environment variable in the eligibility check.

## References

[screwdriver-cd/artifacts-unzip-service](https://cd.screwdriver.cd/pipelines/8204/builds/971599/steps/publish-npm-and-git-tag) uses GIT_KEY_BASE64 for git ssh. 

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
