### PR TITLE
feat: check either GIT_KEY_BASE64 or GIT_KEY present

### DIFF
--- a/publish.sh
+++ b/publish.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 # GIT_KEY = SSH Deployment key
 # NPM_TOKEN = NPM token for publishing the module
-if [ -z "$GIT_KEY" ] || [ -z "$GIT_KEY_BASE64" ] || [ -z "$NPM_TOKEN" ]; then
+if { [ -z "$GIT_KEY" ] && [ -z "$GIT_KEY_BASE64" ]; } || [ -z "$NPM_TOKEN" ]; then
   echo Unable to publish, missing environment variables
   exit 2
 fi


### PR DESCRIPTION
## Context

The prefix check in `publish.sh` currently requires `GIT_KEY_BASE64`, `GIT_KEY`, and `NPM_TOKEN` to all be present.

## Objective

Modify the check so that the script proceeds if either `GIT_KEY_BASE64` or `GIT_KEY` is set, rather than requiring both.

## References

## License

I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
